### PR TITLE
Updating mbed-os to mbed-os-5.11.5

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#ecb3c8c837162c73537bd0f3592c6e2a42994045
+https://github.com/ARMmbed/mbed-os/#51d55508e8400b60af467005646c4e2164738d48


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.11.5 . 