### PR TITLE
Macros and ipv6 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,21 @@ Building for WiFi boards, you need to provide SSID, password and security settin
 
 Building for boards that have more that one network interface, you might need to override `target.network-default-interface-type` variable.
 
+### Configuring mbedtls
+
+It might be necessary to configure the mbedtls library with appropriate macros in mbed_app.json file. Some boards (like UBLOX_EVK_ODIN_W2) will work fine without any additional configuration and some of them might require some minimal adjustment. For example K64F will require at least the following macro added:
+
+```
+{
+    "macros": ["MBEDTLS_SHA1_C"],
+    "target_overrides": {
+        ...
+    }
+}
+```
+
+See [mbedtls configuration guidelines](https://github.com/ARMmbed/mbed-os/tree/master/features/mbedtls#configuring-mbed-tls-features) for more details.
+
 ### Building
 
 ```

--- a/README.md
+++ b/README.md
@@ -59,37 +59,39 @@ Mbed OS version: 5.11.4
 
 Connecting to network
 [DBG ][TLSW]: mbedtls_ssl_conf_ca_chain()
-Connecting to api.ipify.org
-[INFO][TLSW]: Starting TLS handshake with api.ipify.org
+Connecting to ifconfig.io
+[INFO][TLSW]: Starting TLS handshake with ifconfig.io
 [DBG ][TLSW]: mbedtls_ssl_setup()
-[INFO][TLSW]: TLS connection to api.ipify.org established
+[INFO][TLSW]: TLS connection to ifconfig.io established
 [DBG ][TLSW]: Server certificate:
     cert. version     : 3
-    serial number     : 92:0F:D1:B7:FE:4B:88:AE:B6:ED:5A:B0:C3:6C:56:68
-    issuer name       : C=GB, ST=Greater Manchester, L=Salford, O=COMODO CA Limited, CN=COMODO RSA Domain Validation Secure Server CA
-    subject name      : OU=Domain Control Validated, OU=PositiveSSL Wildcard, CN=*.ipify.org
-    issued  on        : 2018-01-24 00:00:00
-    expires on        : 2021-01-23 23:59:59
-    signed using      : RSA with SHA-256
-    RSA key size      : 2048 bits
+    serial number     : 3F:28:36:EC:98:F3:1D:A8:10:6F:96:47:3E:9C:8B:B2
+    issuer name       : C=GB, ST=Greater Manchester, L=Salford, O=COMODO CA Limited, CN=COMODO ECC Domain Validation Secure Server CA 2
+    subject name      : OU=Domain Control Validated, OU=PositiveSSL Multi-Domain, CN=sni44589.cloudflaressl.com
+    issued  on        : 2018-10-03 00:00:00
+    expires on        : 2019-04-11 23:59:59
+    signed using      : ECDSA with SHA256
+    EC key size       : 256 bits
     basic constraints : CA=false
-    subject alt name  : *.ipify.org, ipify.org
-    key usage         : Digital Signature, Key Encipherment
-    ext key usage     : TLS Web Server Authentication, TLS Web Client Authentication
-
-
+    subject alt name  : sni44589.cloudflaressl.com, *.8bit.tv, *.allseniorlivingrun.live, *.allseniorlivingsyes.live, *.andautoinsurancebuy.live, *.andglobaldentalimplantpurchesok.live, *.andseniorlivingkey.live, *.anokbestattungsversicherungok.live, *.anokunsoldsuvok.live, *.aptuklifeinsuranceok.live, *.authentic8.blog, *.beseniorparttimeshype.live, *.bewomencancertreatmentsok.live, *.bloodpressurehome.com, *.cancertreatm
 [INFO][TLSW]: Certificate verification passed
-[DBG ][TLSW]: send 58
+[DBG ][TLSW]: send 56
 HTTP/1.1 200 OK
-Server: Cowboy
+Date: Tue, 12 Mar 2019 14:50:04 GMT
+Content-Type: text/html; charset=utf-8
+Transfer-Encoding: chunked
 Connection: close
-Content-Type: text/plain
-Vary: Origin
-Date: Mon, 25 Feb 2019 13:13:10 GMT
-Content-Length: 11
-Via: 1.1 vegur
+Set-Cookie: __cfduid=d7c5c5e5d175b7367e562180bdca57c2d1552402204; expires=Wed, 11-Mar-20 14:50:04 GMT; path=/; domain=.ifconfig.io; HttpOnly
+Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+Server: cloudflare
+CF-RAY: 4b66940f3911cc9d-WAW
 
-85.76.45.48
+<html>
+... 
+ifconfig.io's HTML code
+...
+</html>
+
 [INFO][TLSW]: Closing TLS
 [DBG ][TLSW]: mbedtls_ssl_conf_ca_chain()
 Done

--- a/main.cpp
+++ b/main.cpp
@@ -33,7 +33,7 @@ int main(void)
     char *buffer = new char[256];
     nsapi_size_or_error_t result;
     nsapi_size_t size;
-    const char query[] = "GET / HTTP/1.1\r\nHost: api.ipify.org\r\nConnection: close\r\n\r\n";
+    const char query[] = "GET / HTTP/1.1\r\nHost: ifconfig.io\r\nConnection: close\r\n\r\n";
 
     mbed_trace_init();
 
@@ -67,8 +67,8 @@ int main(void)
         return result;
     }
 
-    printf("Connecting to api.ipify.org\n");
-    result = socket->connect("api.ipify.org", 443);
+    printf("Connecting to ifconfig.io\n");
+    result = socket->connect("ifconfig.io", 443);
     if (result != 0) {
         printf("Error! socket->connect() returned: %d\n", result);
         goto DISCONNECT;

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,5 +1,4 @@
 {
-    "macros": ["MBEDTLS_SHA1_C"],
     "target_overrides": {
         "*": {
             "platform.stdio-convert-newlines": true,


### PR DESCRIPTION
Two commits are in the scope of this PR:

1) When the macro `MBEDTLS_SHA1_C` is defined, UBLOX_EVK_ODIN_W2 won't compile. Rather than explain to users that this has to be removed it is better to have it removed by default (and keep the mbed_app.json file simple) and explain to users when macros should be added, including a link to full mbedtls configuration guidelines.

2) The api.ipify.org does not have AAAA record and therefore cannot handle IPv6 traffic. To get around this I tried a number of websites. ifconfig.io, which is used in mbed-os-example-sockets works fine with IPv6, but it returns a large HTML file instead of a simple output, like api.ipify.org does.
I found two websites which have a simplistic output: checkip.amazonaws.com and icanhazip.com but they both failed to accept our TLS certificate... In the end I stayed with ifconfig.io and cut short the sample documentation output, as the HTML contents are not really interesting for the sake of this example.