### PR TITLE
Replace string-based APIs with SocketAddress-based ones

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -53,27 +53,34 @@ int main(void)
 
     printf("Connecting to network\n");
     result = net->connect();
-    if (result != 0) {
+    if (result != NSAPI_ERROR_OK) {
         printf("Error! net->connect() returned: %d\n", result);
         return result;
     }
 
     TLSSocket *socket = new TLSSocket;
     result = socket->set_root_ca_cert(cert);
-    if (result != 0) {
+    if (result != NSAPI_ERROR_OK) {
         printf("Error: socket->set_root_ca_cert() returned %d\n", result);
         return result;
     }
 
     result = socket->open(net);
-    if (result != 0) {
+    if (result != NSAPI_ERROR_OK) {
         printf("Error! socket->open() returned: %d\n", result);
         return result;
     }
 
     printf("Connecting to ifconfig.io\n");
-    result = socket->connect("ifconfig.io", 443);
-    if (result != 0) {
+    SocketAddress addr;
+    result = net->gethostbyname("ifconfig.io", &addr);
+    if (result != NSAPI_ERROR_OK) {
+	printf("Error! DNS resolution for ifconfig.io failed with %d\n", result);
+    }
+    addr.set_port(443);
+
+    result = socket->connect(addr);
+    if (result != NSAPI_ERROR_OK) {
         printf("Error! socket->connect() returned: %d\n", result);
         goto DISCONNECT;
     }

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b81aeff1a3e171c6421984faa2cc18d0e35746c0
+https://github.com/ARMmbed/mbed-os/#64853b354fa188bfe8dbd51e78771213c7ed37f7


### PR DESCRIPTION
String-based APIs were marked deprecated and replaced by `SocketAddress`-based APIs in https://github.com/ARMmbed/mbed-os/pull/11914.
This PR switches the example to the new API and removes the deprecated one.
To get this compile I updated `mbed-os.lib` version to 5.15.