### PR TITLE
Rearrange tls-related function calls and add explicit set_hostname()

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -73,6 +73,8 @@ int main(void)
         return result;
     }
 
+    socket->set_hostname("ifconfig.io");
+
     result = socket->set_root_ca_cert(cert);
     if (result != NSAPI_ERROR_OK) {
         printf("Error: socket->set_root_ca_cert() returned %d\n", result);

--- a/main.cpp
+++ b/main.cpp
@@ -58,19 +58,6 @@ int main(void)
         return result;
     }
 
-    TLSSocket *socket = new TLSSocket;
-    result = socket->set_root_ca_cert(cert);
-    if (result != NSAPI_ERROR_OK) {
-        printf("Error: socket->set_root_ca_cert() returned %d\n", result);
-        return result;
-    }
-
-    result = socket->open(net);
-    if (result != NSAPI_ERROR_OK) {
-        printf("Error! socket->open() returned: %d\n", result);
-        return result;
-    }
-
     printf("Connecting to ifconfig.io\n");
     SocketAddress addr;
     result = net->gethostbyname("ifconfig.io", &addr);
@@ -78,6 +65,19 @@ int main(void)
 	printf("Error! DNS resolution for ifconfig.io failed with %d\n", result);
     }
     addr.set_port(443);
+
+    TLSSocket *socket = new TLSSocket;
+    result = socket->open(net);
+    if (result != NSAPI_ERROR_OK) {
+        printf("Error! socket->open() returned: %d\n", result);
+        return result;
+    }
+
+    result = socket->set_root_ca_cert(cert);
+    if (result != NSAPI_ERROR_OK) {
+        printf("Error: socket->set_root_ca_cert() returned %d\n", result);
+        return result;
+    }
 
     result = socket->connect(addr);
     if (result != NSAPI_ERROR_OK) {


### PR DESCRIPTION
With https://github.com/ARMmbed/mbed-os-example-tls-socket/pull/40, the example started failing on connection. It turns out that:
1) The call order was wrong - `set_ca_cert()` must go before `open()`
2) `set_hostname()` is required for this connection to work (our Greentea tests work fine without it).

The second point must be considered separately, as the `TLSSocket::connect` was removed with the recent changes in string-based APIs, but it seems it might have to stay to call the `set_hostname`...