### PR TITLE
Update for mbed-os-5.15.5

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e4b81f67f939a0c0b11c147ce74aa367271e1279
+https://github.com/ARMmbed/mbed-os/#6a244d7adffc0e93872cfc880e539ee11bbc6002


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-5.15.5 release of mbed-os. 