### PR TITLE
Deprecate example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-![](./resources/official_armmbed_example_badge.png)
+# This example is DEPRECATED
+
+### Please use [sockets example](https://github.com/ARMmbed/mbed-os-example-sockets) instead.
+
+---
+
+
 # TLSSocket example for Mbed OS
 
 This examples application demonstrates the usage of `TLSSocket` API. To understand how secure sockets work in Mbed OS, please refer to the [Documentation](#documentation) section below.

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/
+https://github.com/ARMmbed/mbed-os/#d6784c3ee6ada8e886801d0197904d3ab94c891c


### PR DESCRIPTION
TLS is now part of the sockets example.